### PR TITLE
feat; contributor post tag for blogs

### DIFF
--- a/feat; contributor post tag for blogs
+++ b/feat; contributor post tag for blogs
@@ -1,0 +1,1 @@
+Add to the blog a 'contributor post' tag and button when it is labeled 'contributor post' 


### PR DESCRIPTION
Is possible to add the 'contributor post' tag and a 'contributor' button to the blog when it is labeled in the GH PR 'contributor post' that way it is clear what is being submitted by external contributors. 