### PR TITLE
fix: [MYG: 2,3,4] header formatting + cleanup links

### DIFF
--- a/posts/2023-05-26_myg-april/README.md
+++ b/posts/2023-05-26_myg-april/README.md
@@ -6,59 +6,59 @@ tags: [gnoland, gnovm, tm2]
 authors: [christina]
 ---
 
-**The More You Gno 2: Gno.land Developer Updates**
+## The More You Gno 2: Gno.land Developer Updates
 
 Over the past few weeks, our core devs and ecosystem contributors have been making massive strides on Gno.land. There’s a lot to cover in the second edition of *The More You Gno*, from updates on Tendermint2 and GnoVM to stack/frames management, Gno IDE, and plenty more. We’ll also see what some of the external teams contributing to the platform have been up to, including Gno.land’s first decentralized exchange, GnoSwap, and Adena compatibility with GRC20 tokens. Check it out.
 
-**Tendermint2**
+## Tendermint2
 
 We’re making steady development progress on Tendermint2, which focuses on simplicity of design, minimal code, minimal dependencies, modular dependencies, and completeness. For the time being, Tendermint2 will stay in the main repo in a top-level folder named Tendermint2. This is the official location to develop and improve the consensus protocol until it is stable enough to be extracted from the Gno repo and become a standalone project. Currently, Tendermint2 depends on GnoVM, however, we are working to unlink this dependency and build a basic demo Tendermint2 chain and Client.
 
 Tendermint2 JS/TS Client is a JavaScript/TypeScript client implementation for Tendermint2-based chains. The client will make it easier for developers to interact with Tendermint2 chains, with a simplified API for account and transaction management, removing a ton of manual work and allowing developers to focus on building their dApps. You can [read more about the client here](https://www.npmjs.com/package/@gnolang/tm2-js-client). In addition to the Tendermint2 JS/TS client, we also created a Gno JS/TS client that just extends the TM2 one to provide Gno-specific functionality. You can read more about this here.
 
-**Game of Realms**
+## Game of Realms
 
 The incentivized competition to find the best contributors to Gno.land continues in phase one, with slow but steady progress being made. Nir1218 initiated an Evaluation DAO Kickoff discussion in [issue 792](https://github.com/gnolang/gno/pull/792) to initiate testing code for the key smart contract infrastructure that will power the Gno.land platform. We are also interviewing architects for the core team with experience in governance modules and creating new economies on-chain, and a new DevRel team member will be joining us soon to create awesome tutorials and documentation to advance Game of Realms further. Gno.land must be built by the community and we will not rush to push Game of Realms to the second phase until we have found quality contributors to complete the challenge tasks and become the platform’s first founding members.
 
-**Gno IDE**
+## Gno IDE
 
 Our core development team is working on a web-based IDE for Gno.land that will greatly improve the developer experience, allowing builders to quickly spin up Gno realms and packages right on their browsers just by visiting a web app. Currently named Gno IDE but with a rebranding on the horizon, this intuitive product focuses on ease of use and improved UX, and will include all the features you’d expect from an IDE, such as auto compilation in the editor, debugging, extensive testing capability, and powerful APIs like IntelliJ to supercharge your programming.
 
 Gno IDE currently has multiple modes to support different use cases, including a normal mode for everyday programming, similar to a standard code editor, a presentation mode for video calls or screen sharing, and an embedded mode to extend functionality, allowing you to embed the IDE directly into websites and blogs. You can also choose to edit your code in Emacs or Vim and easily switch between steps, from previous to next, making creating your tutorials and blog posts more intuitive. Watch out for more to come on Gno IDE soon, and if you want to contribute by creating a plugin for your favorite editor, open a PR to win contribution points.
 
-**Stack/Frames Management**
+## Stack/Frames Management
 
 The stack/frames is an integral part of the virtual machine (VM) and the language. Stack/frames provide context for smart contract developers, enabling them to access useful information, such as the original caller, or to determine if a contract is being called through another one. The current implementation is limited in scope and relies on fixed positions in the stack which can lead to inconsistencies.
 
 There is an ongoing [issue 683 open here](https://github.com/gnolang/gno/issues/683) and we have continued to work on enhancing stack/frames development over the last month. We’re adding a new function in the standard library std.PrevRealm (previously GetRealmCaller). Currently, we only have GetOrigCaller, which returns the user calling the first realm. This is not secure and we need a way to call the previous caller. This will allow a realm to handle GRC20 treasuries. See [issue 667](https://github.com/gnolang/gno/pull/667) and [issue 634](https://github.com/gnolang/gno/issues/634) for further details.
 
-**Dealing with Panics in Native Functions**
+## Dealing with Panics in Native Functions
 
 We have devised a solution for dealing with panics in native functions, [see pull request 732](https://github.com/gnolang/gno/pull/732). Previously, when there was a panic in a native function, we could not recover it in Gno code. An example of this was the assert origin call, which panicked if the call was not a direct call from a transaction. Based on discussions with contributors, we’ve agreed that native functions should never panic, but if they panic, they panic with machined Gno panic. This gives us the choice in a native function to code a Gno panic, or, if it's a very bad panic, use Go panic so that we know the Gno code is unable to recover it.
 
-**Logic Upgrading**
+## Logic Upgrading
 
 Making it possible to upgrade your logic is definitely out of scope for the first version of Gno.land, however, it’s an important issue that we have begun to discuss so that we can place certain restrictions on it, such as allowing upgrades when we consider them safe enough to be compatible with imports. Another idea is to work on creating workflows where migrations become something official. This way, we could define ways to migrate a contract completely in a single transaction at the chain level. Once everything is working and approved as the previous contract is parsed or archived, the new one gets the data. We will revisit this topic after the first version of Gno.land reaches the mainnet.
 
-**Garbage Collection**
+## Garbage Collection
 
 In terms of garbage collection, we don’t have memory leaks as such but we do have defacto memory leaks. By the VM having references to all objects, they won’t be released by Go’s underlying GC. We have some form of reference counting but it is only done at the end of a transaction. We have implemented a mark-and-sweep garbage collector and are working on the VM runtime to manage the objects and signal to the garbage collector to release them when they are no longer needed. This is done by adding the notion of a heap, which is managed by the garbage collector.
 
-**GnoVM**
+## GnoVM
 
 Developing GnoVM is an ongoing task and we will likely need to fork the GnoVM to create different competing versions. GnoVM will be complete, limited in features, and serve as the only interpreter, an enduring reference point over time. Future versions of GnoVM will be designed to incorporate CosmWasm so that all Cosmos chains can have CosmWasm enabled and the VM can run directly on the browser and execute tasks on the browser without requiring to make an API call, making it faster. To do this, we can make a Gno compiler in WebAssembly without changing the code because Go supports WASM cross-compilation.
 
 We plan on making a competing version of the original minimalist GnoVM, such as a Rust version with a JIT compiler using LLVM as a backend.
 
-**Ecosystem Updates**
+## Ecosystem Updates
 
 Since our last update, the Gno.land community continues to expand with awesome teams and contributors building cool infrastructure and projects on the platform. Below, we take a look at the largest developments of the past few weeks and extend a special thanks to everyone helping us build Gno.land.
 
-**Teritori**
+## Teritori
 
 Teritori blockchain and multi-chain hub launched in November 2022, allowing IBC and non-IBC communities to connect, create groups, exchange tokens and NFTs, and launch new projects. Teritori’s idea for building on Gno.land is to create a multi-chain experience for users with a web portal, NFT marketplace, and social feed that will grow the community, and gradually integrate smart contracts and realms. This will promote Gno.land to more developers and showcase all the dApps being built through an easy-to-navigate dApp store. In the coming weeks, Teritori will work with the Onbloc team to integrate the Athena wallet into their portal as well as discuss ideas for promoting Game of Realms to new developers.
 
-**Onbloc**
+## Onbloc
 
 Onbloc is one of the Gno.land ecosystem’s most active contributors, responsible for building the Adena wallet and the block explorer Gnoscan. The team has also been working on creating an official Gno SDK that will allow developers to interact with Gno.land more easily, and remove some of the current friction. Onbloc opened [issue 701](https://github.com/gnolang/gno/issues/701) on GitHub primarily for developers who either have their own web app or are building a JavaScript app and want to work with Gno in some way. Currently, developers need to do a lot of manual work, which Gno SDK will abstract away, improving the workflow and developer experience. If you have any ideas or feedback, please contribute to the aforementioned issue.
 
@@ -70,7 +70,7 @@ And speaking of decentralized exchanges, Onbloc is also building Gnoswap, the fi
 
 As for the contract side, Onbloc is actively working on its development with help from the core members of Gno.land. The code will be open-sourced for full transparency once the basic functions are ready.
 
-**New Core Contributors**
+## New Core Contributors
 
 We’re excited to welcome two new core team members, Antonio and Zack. Antonio joined us in April in the core team, bringing with him vast experience in IPFS, and writing Git servers in Go. Zack is our first “tinkerer in residence” and will try to bootstrap the ecosystem of small contracts and small libraries. He will also be writing apps and helping us design a system to better share and showcase our work with a super UX for team builders and open-source addicts.
 
@@ -78,7 +78,7 @@ Antonio is already hard at work researching a benchmarking dashboard that will s
 
 Zack is working on a microblog project. As an experienced web2 Go programmer, Zack is transitioning to web3. Since he’s interested in incentivized social networks, the microblog project will be his first realm, as a Twitter-style blog without titles, where each user has their own page based on their address. Check out [issue 391](https://github.com/gnolang/gno/pull/391) for more details.
 
-**Developer Events**
+## Developer Events
 
 Over the past few weeks, our core devs have been mainly focused on building but they’re preparing to speak at some exciting events in the coming months. Catch up with Manfred at BUIDL Asia, in Seoul, South Korea, from June 5 - 9. We’re co-hosting a side event with Onbloc, Code States, and Cosmostation on June 5, so be sure to register if you’re in town! We’ll also be at EthBelgrade in Serbia from June 2 - 4, and GopherCon in Berlin from June 26 - 29, so stop by and say hello.
 

--- a/posts/2023-07-11-myg-3/README.md
+++ b/posts/2023-07-11-myg-3/README.md
@@ -12,7 +12,7 @@ We’ve been busy since the last edition of *The More You Gno,* with the Gno.lan
 
 ## Gno by Example
 
-We recently launched [Gno by Example](https://gno-by-example.com/), our equivalent to [Solidity by Example](https://solidity-by-example.org/), where you can see tutorials and code snippets to help you learn and get more easily onboarded to Gno.land. Gno by Example is designed to be community-run with a front-end app and tutorials in markdown. There’s also a specific markdown syntax where you can embed certain file fragments to make your tutorials more structured. We’d love to build this into the ultimate resource center for Gno.land, so feel free to [contribute](https://github.com/gnolang/gno-by-example) with new tutorials and sections. Contributions here are eligible for rewards from the Game of Realms competition.
+We recently launched [Gno by Example](https://gno-by-example.com/), our equivalent to both [Solidity by Example](https://solidity-by-example.org/) and [Go by Example](https://gobyexample.com/), where you can see tutorials and code snippets to help you learn and get more easily onboarded to Gno.land. Gno by Example is designed to be community-run with a front-end app and tutorials in markdown. There’s also a specific markdown syntax where you can embed certain file fragments to make your tutorials more structured. We’d love to build this into the ultimate resource center for Gno.land, so feel free to [contribute](https://github.com/gnolang/gno-by-example) with new tutorials and sections. Contributions here are eligible for rewards from the Game of Realms competition.
 
 ## GnoVM
 

--- a/posts/2023-07-11-myg-3/README.md
+++ b/posts/2023-07-11-myg-3/README.md
@@ -6,51 +6,51 @@ tags: [gnoland, gnovm, tm2]
 authors: [christina]
 ---
 
-**The More You Gno - Gno.land Monthly Updates 3**
+## The More You Gno - Gno.land Monthly Updates 3
 
 We’ve been busy since the last edition of *The More You Gno,* with the Gno.land core team and ecosystem partners present at various global developer events. We’ve visited many gnomes (and gnomes-in-the-making) around the world from Berlin to Belgrade, spreading the word about Gno.land and growing our expanding community. Aside from all the networking, Gno.land is taking shape with a new iteration of our website, the Gno.land Funding and Grants Program, and a host of developer updates as always. Let’s dive in.
 
-**Gno by Example**
+## Gno by Example
 
 We recently launched [Gno by Example](https://gno-by-example.com/), our equivalent to [Solidity by Example](https://solidity-by-example.org/), where you can see tutorials and code snippets to help you learn and get more easily onboarded to Gno.land. Gno by Example is designed to be community-run with a front-end app and tutorials in markdown. There’s also a specific markdown syntax where you can embed certain file fragments to make your tutorials more structured. We’d love to build this into the ultimate resource center for Gno.land, so feel free to [contribute](https://github.com/gnolang/gno-by-example) with new tutorials and sections. Contributions here are eligible for rewards from the Game of Realms competition.
 
-**GnoVM**
+## GnoVM
 
 We continue developing GnoVM and invite you to provide feedback on what can be improved. This month, there have been a lot of discussions about how to improve native bindings and use the Gno machine in native function calls. Native function calls are well-defined in Go code generation and Go templates but need some modifications for GnoVM. For example, since new native functions already exist in the Gno code, when we try to define a native function, calling the function doesn’t yield the desired result. We’ve created a bunch of panics and tried writing out native functions to see what goes on for them, in an investigation that will go on for the next few weeks. Got any ideas? Please contribute. ([PR 859](https://github.com/gnolang/gno/pull/859)).
 
-**Testnets**
+## Testnets
 
 Talk about testnets has come up a lot in recent weeks and how to best proceed. Some gnomes are asking for a multi-node testnet to allow for great experimentation, whereas others prefer to keep the testnet single-node. There are advantages and disadvantages to both approaches and we are still listening to feedback and ideas. However, we will likely keep testnet 3 single-node and focus on the language while having a second dedicated multi-node testnet where devs can get creative, think outside of the box, test performance, consensus, and everything they need to push the chain to its limits. We’ve created a new [Hackerspace](https://github.com/gnolang/hackerspace) Repository for the multi-node testnet to prevent spam on the main repo, so please use it to share your scripts, posts, snippets, etc.
 
-**Native Coins and GRC-20 Tokens**
+## Native Coins and GRC-20 Tokens
 
 We uncovered some significant issues with the banker module ([PR 393](https://github.com/gnolang/gno/pull/393)) regarding minting and burning tokens with the package minter. It was not scoping, filtering, or minting tokens correctly, making it possible to mint and burn unlimited tokens, including GNOT. We want to allow any realm to create its own token and run multiple tokens on their chains, but we need a prefix for security to resolve the issue and allow anyone to create GRC20 smart-contract-based coins but not native coins. We continue to work with small fixes on this issue and will reopen the PR soon.
 
-**Gno.land Funding and Grants Program**
+## Gno.land Funding and Grants Program
 
 Last month we released our Funding and Grants Program to encourage more developers, researchers, educators, and tinkerers to interact with Gno.land. If you’re interested in experimenting with Gnolang (Gno) and building innovative dApps, tooling, products, or infrastructure, check out our GitHub [Funding and Grants](https://github.com/gnolang/ecosystem-fund-grants) page for further information on how you can apply. Start contributing to Gno.land or Game of Realms as this is a prerequisite of the funding and grant application process.
 
-**Developer Relations**
+## Developer Relations
 
-The Gno core team is growing! We hired a new DevRel last month and are looking to take on another dev for this open position, so if you’re interested, head over to our [careers page here](https://jobs.lever.co/allinbits) and apply! You can expect to see a lot more documentation, FAQs, tutorials, and onboarding materials in the coming weeks and months.
+The Gno core team is growing! We hired a new DevRel last month and are looking to take on another dev for this open position, so if you’re interested, head over to our [careers page](https://jobs.lever.co/allinbits) and apply! You can expect to see a lot more documentation, FAQs, tutorials, and onboarding materials in the coming weeks and months.
 
-**Ecosystem Updates**
+## Ecosystem Updates
 
 Our community of gnomes continues to expand, making tons of activity and progress over the past few weeks. Let’s see what they’ve been up to below.
 
-**Onbloc**
+## Onbloc
 
-Onbloc has been super active this month attending and co-hosting IRL events and networking to find new gnomes about town. Among other updates, Onbloc has completed the first integration of Tendermint2 JS with the Adena wallet and will continue to swap out their existing libraries with TM2JS wherever applicable to ensure that they are as tightly integrated as possible. The team has also open-sourced the Gnoscan block explorer, so if you’re interested in contributing, hop on over to [Gnoscan here](https://gnoscan.io/) or the [GitHub repo](https://github.com/onbloc/gnoscan) here.
+Onbloc has been super active this month attending and co-hosting IRL events and networking to find new gnomes about town. Among other updates, Onbloc has completed the first integration of Tendermint2 JS with the Adena wallet and will continue to swap out their existing libraries with TM2JS wherever applicable to ensure that they are as tightly integrated as possible. The team has also open-sourced the Gnoscan block explorer, so if you’re interested in contributing, hop on over to [Gnoscan](https://gnoscan.io/) or the [GitHub repo](https://github.com/onbloc/gnoscan).
 
-**Teritori**
+## Teritori
 
 Another of our first cohorts from the Grants program, Teritori continues to churn out awesome work and expand its growing team. This month, Teritori has been busy integrating Adena with the Teritori app and working on the DAO contract to build a DAO deployer and various DAO standards and templates for DAO creation. Teritori’s target is to focus on a moderation DAO that can be used for content moderation in social feeds and boards. In the coming weeks, the team plans to integrate the DAO contract into the UI to allow the community to launch a DAO and experiment on the testnet. They have also made an effort to really integrate Gno users by adding .gno at the end of nicknames for people to use. All our grant recipients are documenting their journeys in the hackerspace repo, check out [Teritori’s](https://github.com/gnolang/hackerspace/issues/7) journey.
 
-**Resident Tinkerer, Zack**
+## Resident Tinkerer, Zack
 
 Another grant receiver, Zack, has been making significant progress on his microblogging project. You can check out the specs on GitHub ([PR 791](https://github.com/gnolang/gno/pull/791)) or watch the informative tutorial video, [Go to Gno: How to Build a Microblog](https://www.youtube.com/watch?v=F-_dadxcRJM). You’ll find this especially useful if you have a background in Go and need some additional insights to turn your hand to blockchain coding. Zack has also been working on an implementation of a smart contract for creating and transferring text-based NFTs that conform to haiku poetry standards (find out more on GitHub ([PR 860](https://github.com/gnolang/gno/pull/860)). Other than that, Zack continues his Gnolang journey, “learning and having a lot of fun.”
 
-**EthSeoul, BUIDL Asia, and Getting to Gno**
+## EthSeoul, BUIDL Asia, and Getting to Gno
 
 June saw members of our core team heading over to Seoul, South Korea, for a week of networking, talks, and events. Our VP of Engineering Manfred Touron gave a keynote on the evolution of smart contracts and an introduction to Gno.land for participants of EthSeoul, followed by a fascinating dive into Proof of Contribution at BUIDL Asia, where we also had a booth. It was an honor to meet so many talented and motivated Korean developers and contributors from around the globe. Seoul is a hotbed of up-and-coming talent and we’ll definitely be back soon.
 
@@ -60,11 +60,11 @@ EthSeoul - [Watch the talk here](https://www.youtube.com/watch?v=_iSsStlmxoU)
 
 BUIDL Asia - [Watch the talk here](https://www.youtube.com/watch?v=v6k3NHm5vcE)
 
-**EthBelgrade**
+## EthBelgrade
 
 Core contributor Milos Zivkovic rocked the Gno.land presence at EthBelgrade in Serbia, giving an introductory workshop about Gno.land, called 'Alice in Gno.land'. Being the first Ethereum conference organized in Serbia, there were lots of attendees from all over the Balkans. Participants joined in a journey through the enchanting realm of Gnolang and the Gno.land platform. Most of the participants were not aware of Goland before but were avid Gophers eager to learn more about the application of the Gno language in blockchains.
 
-**GopherCon Berlin**
+## GopherCon Berlin
 
 The Gno.land team also had a blast last month at the European edition of GopherCon in Berlin. We had a booth at the event for two days, where we networked, talked about all things Gno, made some amazing connections, and even shared some live code! We’re looking to build an active, open-source Gopher contributor group in Gno.land, so stay tuned for more on that soon.
 

--- a/posts/2023-09-04-myg-4/README.md
+++ b/posts/2023-09-04-myg-4/README.md
@@ -6,17 +6,17 @@ tags: [gnoland, gnovm, tm2]
 authors: [christina]
 ---
 
-**The More You Gno 4: Gno.land Developer Updates**
+## The More You Gno 4: Gno.land Developer Updates
 
 We’ve had more on our plates than ever over the last few weeks, with a huge team presence in Paris at EthCC and Nebular Summit in July, an opening talk at Stanford Blockchain Club in August by Gno.land’s founder Jae Kwon, and some awesome contributions from Gno.land grantees and ecosystem partners, including the first demos of Gnoswap and Teritori’s social platform and DAO deployer. We continue to make solid progress on GnoVM, an alternative VM in Rust, Tendermint2, native bindings, and much more. Check out our latest developer updates below.
 
-**Upgrade Strategy for AVL Between GitHub and test3.gno.land**
+## Upgrade Strategy for AVL Between GitHub and test3.gno.land
 
 One ongoing discussion is about an incompatibility bug that affects many things we do on Gno.land. The current AVL implementation on the testnet is outdated and does not match the AVL implementation users get when they pull in the latest master branch. Therefore, building and deploying contracts on a local Gno chain (with the latest master changes) and deploying those same contracts on the testnet may fail due to this incompatibility. We need to find a way to seamlessly integrate these two approaches. Ideally, when you write code on the master branch on GitHub, it should work on the testnet as well.
 
 In [issue 970](https://github.com/gnolang/gno/issues/970), you can find details of five different proposed solutions to implement this upgrade strategy, from resetting the whole blockchain (which would mean losing on-chain content and debugging information) to implementing a migration feature specifically for testnets that allows developers to rename packages and patch their contracts before publishing them. There are pros and cons to each proposal, and we continue to work together to find the best way forward.
 
-**Encoding JSON and the Discussion Around Reflection**
+## Encoding JSON and the Discussion Around Reflection
 
 Some contributors have highlighted the need for native JSON encoding, and we are discussing how best to approach it. See [issue 808](https://github.com/gnolang/gno/issues/808) for further details. One idea is to copy the code from encoding JSON in the standard library Go and take it over to Gno, but we would need to have reflection to do that. So, the important question here is whether we want to have reflection and, if so, what it should look like. We could emulate Go’s reflection package with some added elements, like being able to inspect the realm state, but we would need to be extremely careful about how we do this.
 
@@ -24,7 +24,7 @@ For example, should users be able to read private fields of external packages th
 
 Another solution is the partial implementation of reflection. In [issue 971](https://github.com/gnolang/gno/issues/971), Gno.land core engineer Petar discusses introspection, which involves implementing reflection as Go has it now but enabling only one of its two main capabilities: the ability to inspect types, but not the ability to modify code. The main difference between introspection and reflection is that, since it is done at compile time, it is completely type-safe. This discussion is ongoing.
 
-**Alternative GnoVM Implementations**
+## Alternative GnoVM Implementations
 
 To deliver the best possible virtual machine, we’re working on two different implementations of GnoVM. Petar has spent the last three weeks developing a new GnoVM implementation written in Rust. His work is still private as the machine is not yet ready for public use, but he will soon make the code public for your inspection. Rust gives the ability to write more performant code and, in some scenarios, the Rust GnoVM can run up to 20 times faster than the GnoVM at roughly 87 milliseconds compared to 2,000 milliseconds on a Fibonacci benchmark, which is a considerable improvement in speed.
 
@@ -36,19 +36,19 @@ Core team dev Marc has also started an initiative to improve the Go GnoVM so tha
 
 The VM must be fast, secure, and performant in many ways. In either version, the AST will be stored on the blockchain, whereas the bytecode is only an internal representation that doesn't affect the users. We must still consider any potential architecture consequences between bytecode and AST before deciding whether to change. Marc’s WIP code is still in a private repo, but you’ll be able to inspect it soon and make a comparison of the VM implementations in the coming weeks. The decision about the direction of GnoVM is still very much TBD; however, the Rust GnoVM will not replace the Go GnoVM but will complement it, eventually giving validators the choice of which to run.
 
-**Defining Wording for People/Documentation and Consistency**
+## Defining Wording for People/Documentation and Consistency
 
-Issue [1024](https://github.com/gnolang/gno/issues/1024) discusses the need to define the wording we use throughout our documentation, for example, how we name a module, package, sub-module, etc. Once we have the wording defined, we will set the GnoVM to only accept elements with the correct naming. The importance of wording affects the design choice of the whole project and how we go about versioning for the best possible user experience.
+[Issue 1024](https://github.com/gnolang/gno/issues/1024) discusses the need to define the wording we use throughout our documentation, for example, how we name a module, package, sub-module, etc. Once we have the wording defined, we will set the GnoVM to only accept elements with the correct naming. The importance of wording affects the design choice of the whole project and how we go about versioning for the best possible user experience.
 
 For example, is mt/board/admin part of the same realm of mt boards, or is it its own realm? Can we work with both by adding patterns to have some realms responsible for hosting data and others responsible for having more privileged actions? How do we split a complex realm into sub-libraries and sub-realms? We want to define the documentation and the logic for this and have begun to touch on this issue. We will discuss this in greater depth in the upcoming developer calls.
 
-**Improving the GRC20/Foo20 APIs**
+## Improving the GRC20/Foo20 APIs
 
 When working on the specs for a Merkle airdrop contract, Albert came against some issues with users initiating airdrop reward claims (see [PR 906](https://github.com/gnolang/gno/pull/906) for more details). Currently, when the Merkle airdrop contract tries to execute the reward claim for the user, an instance of the GRC20 contract is used for transferring. Within the GRC20 implementation Transfer() method, the caller (token sender) is fetched using the standard library method std.PrevRealm().
 
 However, calling this method in the Merkle airdrop context returns the user as the caller, not the Merkle airdrop contract, which is an unexpected functionality. We are discussing different ways to tackle this issue efficiently. However, each solution would require possible changes to the GRC20 API and subsequent token implementations. Additionally, as part of [PR 952](https://github.com/gnolang/gno/pull/952), we are looking into improving the standard GRC20 API and possibly resolving the ambiguity with standard library calls that are causing the mentioned issues.
 
-**Client Optimized for CLI, Not Mobile**
+## Client Optimized for CLI, Not Mobile
 
 Our newest contributor to Gno.land, Berty, is developing the mobile version of Gno, which means writing a mobile app to interact directly with the blockchain. The team is facing some issues as they need a client library with utility functions like sign and broadcast, which are used by the command line. This code (tm2/pkg/crypto/keys/client) is not ready for external users yet, and the Gno client is designed for CLI. However, Berty needs a way to interact with the Gno chain from their application and to call the logic without adding the full CLI.
 
@@ -56,57 +56,57 @@ From the existing TypeScript/JavaScript client library (gno-js-client and tm2-js
 
 They are working on an API that interacts with the blockchain and lets them export the code without having to write their own utilities. The API will be minimal, and update the Tendermint2 build script by moving tm2txsync from tm2/cmd to gno.land/cmd (see more details in [PR 1080](https://github.com/gnolang/gno/pull/1080) here). For the time being, Berty will copy the code and use the objects directly until a more convenient API is complete.
 
-**Tendermint2 Development**
+## Tendermint2 Development
 
 In [PR 546](https://github.com/gnolang/gno/pull/546), we introduce file-based transaction indexing. Transaction index parsing should be done as a separate process from the main node, meaning other services can be instantiated to index transactions as readers. The current problem is that there is no way to figure out whether a transaction has failed after it’s been sent out with a broadcast sync, or fetch any kind of receipt information or error reason in the delivered transaction.
 
 So, we’ve started working on an event indexer to index Gno node events, which include transactions. Soon, developers and users will be able to ask the event indexer what happened to the transaction or in which state in its execution it's currently at, and also to retrieve information on other events like block commits as they happen.
 
-**Extending the Functionality of Go**
+## Extending the Functionality of Go
 
 In [issue 919](https://github.com/gnolang/gno/issues/919), Petar proposes extending the functionality of Go by adding constant data structures, arrays, slices, etc. He believes this would benefit users, as they wouldn’t need to create special functions as in Go to simulate this behavior, and it would also catch bugs when there is mutation. There has been a discussion, and Jae has similar ideas with the notion of “invar” expressions, where the resulting value can only be read, not mutated or stored. This would fix the bug where if you pass a pointer (that represents part of your contract state) to another contract, the other party can “steal” it by assigning it to their state, and your contract would fail to execute.
 
 Morgan believes that we should take a different approach as slices have the semantic in Go, where the underlying array is always heap-allocated and modifiable. Introducing constant slices would thus necessarily have to introduce concepts regarding im/mutability of values without the matching constructs that a language like Rust has. To make a compromise and keep compatibility with the Go spec, we are likely to implement this in a transpiler (gnoffeescript) that would implement this feature and be able to transpile to valid Go.
 
-**Grantee and Ecosystem Updates**
+## Grantee and Ecosystem Updates
 
 As you can see, we’ve made a ton of development progress over the last few weeks. We’re also steadily adding more gnomes to our community of builders, and they’re working on the core infrastructure of Gno.land, as well as the permissionless dApps the platform will house. Let’s see what they’ve been up to since the last update.
 
-**Onbloc**
+## Onbloc
 
 Onbloc has been busy, as always, with a slew of updates for us over the last few weeks. The team has been developing Gnoswap, the first Gno.land automated market maker with concentrated liquidity, and they gave us a live demo. On the front end, which is still a work in progress, you can find a one-stop venue for traders to view all the information about tokens on gno.land, so you don’t have to move between Gnoswap and a token aggregator like CoinGecko. You can also see incentivized pools sorted by liquidity, volume, APR, liquidity mining rewards, etc., and a wallet page to check your balances. You will also be able to deposit or withdraw assets from the Interchain when IBC is enabled.
 
-Check out the work they’ve done so far on the Onbloc hackerspace [here](https://github.com/gnolang/hackerspace/issues/29). The team has also released [the documentation](https://docs.gnoswap.io/) about what you can expect from Gnoswap, the rationale behind their design choices, some information about tokenomics, a preview of the UI, and more. Their main focus is on delivering a smooth and welcoming user experience and abstracting away the difficult mechanisms of concentrated liquidity so that the interface is as minimal and simple as possible.
+Check out the work they’ve done so far on the Onbloc [hackerspace](https://github.com/gnolang/hackerspace/issues/29). The team has also released [the documentation](https://docs.gnoswap.io/) about what you can expect from Gnoswap, the rationale behind their design choices, some information about tokenomics, a preview of the UI, and more. Their main focus is on delivering a smooth and welcoming user experience and abstracting away the difficult mechanisms of concentrated liquidity so that the interface is as minimal and simple as possible.
 
-The team will be ready to launch Gnoswap as soon as gno.land reaches mainnet. Feature updates and enhancements will be aligned with the development of the core Gno Stack.  The code for Gnoswap has now been [open-sourced](https://github.com/gnoswap-labs), so you can take a look at everything they’ve done and even make suggestions. In the coming weeks, Onbloc will also work on building core Gno.land infrastructure to support an earlier launch. Find details of this in Onbloc’s [grant submission here](https://github.com/gnolang/ecosystem-fund-grants/pull/4). And be sure to check out Onbloc’s informative 6-episode [blog series](https://medium.com/@gnoswaplabs/why-gno-introducing-gnoswap-dd6acc22e6a1) that features the history of blockchain and exchanges, a deep dive into the Gno Stack, and an introduction to Gnoswap, where they share details of their journey and insights.
+The team will be ready to launch Gnoswap as soon as gno.land reaches mainnet. Feature updates and enhancements will be aligned with the development of the core Gno Stack.  The code for Gnoswap has now been [open-sourced](https://github.com/gnoswap-labs), so you can take a look at everything they’ve done and even make suggestions. In the coming weeks, Onbloc will also work on building core Gno.land infrastructure to support an earlier launch. Find details of this in Onbloc’s [grant submission](https://github.com/gnolang/ecosystem-fund-grants/pull/4). And be sure to check out Onbloc’s informative 6-episode [blog series](https://medium.com/@gnoswaplabs/why-gno-introducing-gnoswap-dd6acc22e6a1) that features the history of blockchain and exchanges, a deep dive into the Gno Stack, and an introduction to Gnoswap, where they share details of their journey and insights.
 
-**Teritori**
+## Teritori
 
 We also saw an awesome demo from the Teritori team, which you can check out at app.teritori.com. Simply connect your Adena wallet to create a user name, start interacting with the social feed, create your own DAO, and add members. The team is working on more extensive documentation to explain how it works in more detail. While still a work in progress, Teritori has developed a cool flagging system that allows you to unfollow content you don’t like or flag content as inappropriate. If posts receive many flags, users can vote on whether to ban them, creating a healthy and supportive social environment free from derogatory content monitored by a like-minded community through a moderation DAO.
 
 The team continues its work on DAO interfaces and has built a useful tool for speeding up the deployment of packages as a workaround until we’ve decided how to best tackle realm versioning. They are also working on the escrow system, which will be useful for the freelance marketplace, and presenting DAO standards documentation.
 
-**Berty**
+## Berty
 
 We have a new contributing team to Gno.land from the Berty private messaging app. This team is working on a mobile version of Gno.land, implementing the WESH protocol, which is available by Bluetooth, local WIFI, or other means, and provides secure censorship-resistant communication between devices. The plan is to be able to provide an alternative transport for Gno applications when the internet is not available and build the skeleton/foundations that enable developers to create Gno-centric mobile apps more easily in the future. Berty brings a ton of experience in off-grid communication and getting apps to run on mobile devices, both Android and iOS.
 
-The team has created its own testnet at [http://testnet.gno.berty.io](http://testnet.gno.berty.io/), which you are welcome to test out and play around with, although they will be restarting and rebooting without prior notice, so be aware that your work could be wiped. In the few short weeks they’ve been working with us, Berty has already finished their first Proof of Concept, a simple app running on iOS and Android. They copied code from the gnokey command line, and now it’s installing and running on mobile and interacting with the blockchain.
+The team has created its own [testnet](http://testnet.gno.berty.io/), which you are welcome to test out and play around with, although they will be restarting and rebooting without prior notice, so be aware that your work could be wiped. In the few short weeks they’ve been working with us, Berty has already finished their first Proof of Concept, a simple app running on iOS and Android. They copied code from the gnokey command line, and now it’s installing and running on mobile and interacting with the blockchain.
 
 Now, Berty is working on a nicer UI for the app and will propose a project to create a formal framework called GnoMobile, which will allow anyone to create their own app and run it on mobile. We look forward to seeing their demo soon.
 
-**Golang Working Group**
+## Golang Working Group
 
 In other news, we've started a bi-weekly [Gnome Golang Working Group](https://github.com/gnolang/hackerspace/issues/15) where we get together and discuss various topics, such as the language-related and theory elements of Go and Gno. We also aim to identify meaningful and reasonable ways to contribute to Golang, Gophers, and the general open-source community and improve our visibility there. We hope to attract more Go devs to the project and provide a “blockchain-less” experience for web2 Go devs.
 
 We've had two meetings so far, and some recent hackerspace issues have already emerged from the discussions. One in particular that we’re actively evaluating is Gnoffee, a transpiler tool inspired by the likes of [CoffeeScript](https://coffeescript.org/) for Go and Gno integration. Gnoffee would be a powerful standalone tool to enhance Go and Gno (blockchain) projects by generating code and seamlessly integrating new features without manual coding. Find out more at the link above.
 
-**EthCC and Nebular Summit**
+## EthCC and Nebular Summit
 
 The Gno.land team was in full force in Paris at the end of July for EthCC, where we met many passionate developers and spread the word about Gno.land and, specifically, how Gnolang compares and contrasts to Solidity. We had a booth during the conference manned by the Gno.land team complete with awesome swag and a continuous presentation in the background playing on a full-screen television.
 
 At Nebular Summit, our VP of Engineering, Manfred Touron, [gave a talk](https://www.youtube.com/watch?v=CtxBajCcTYQ) called ‘Gnolang for Developers: Examining the Core Stack,’ where he broke down the major components of Gno, demonstrated how the upcoming Gno SDK compares with the existing Cosmos SDK, and explained why Gno.land is an excellent choice for accessible and sustainable blockchain development.
 
-**Blockchain Application Stanford Summit (BASS)**
+## Blockchain Application Stanford Summit (BASS)
 
 Jae opened the [Blockchain Application Stanford Summit (BASS)](https://bass.sites.stanford.edu/) event, attended by thousands of students and future blockchain developers. He gave an overview of Gno.land, GnoVM, and Gnolang, and explained the features that make our platform paradigm-shifting and timeless. He also dove into the core of why we’re building Gno.land – to provide a censorship-resistant platform for truth discovery that helps people improve their understanding of the world in an era of information censorship and control.
 


### PR DESCRIPTION
Closes: [#19](https://github.com/gnolang/devrel/issues/19)

This PR introduces formatting fixes for the section headers providing consistent and clean standardization across all MYG (The More You Gno) blog posts.