### PR TITLE
feat: add devrels to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 
 
 # Primary repo maintainers.
-*                            @moul @jaekwon
+* @gnolang/devrels @moul


### PR DESCRIPTION
Closes: #39 

Removes @jaekwon and adds @gnolang/devrels as CODEOWNERS

@leohhhn 