### PR TITLE
feat: add markdown link linter

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,0 +1,22 @@
+name: Markdown
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+  # t Checks the status of hyperlinks in .md files
+    - name: Check links
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'
+        check-modified-files-only: 'yes'

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-  # t Checks the status of hyperlinks in .md files
+  # Checks the status of hyperlinks in .md files
     - name: Check links
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -20,3 +20,5 @@ jobs:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
         check-modified-files-only: 'yes'
+        base-branch: 'main'
+        


### PR DESCRIPTION
Closes: #14

This PR adds a Github action for a Markdown link linter.

NOTE: This job will fail when any of our nodes are down (eg, Staging).

<img width="680" alt="Screenshot 2023-10-19 at 1 52 20 PM" src="https://github.com/gnolang/blog/assets/17755587/976eed05-7d86-473f-9c7a-31e2ed9dd45f">
