### PR TITLE
fix: remove @ symbols from authors

### DIFF
--- a/posts/2023-10-19_dao-moderation-module/README.md
+++ b/posts/2023-10-19_dao-moderation-module/README.md
@@ -3,7 +3,7 @@ title: "Gno.land Moderation DAO Module"
 publication_date: 2023-10-19T01:50:00Z
 slug: gnoland-moderation-dao-module
 tags: [gnoland, dao, moderation, teritori]
-authors: [@ferrymangmi, @zxxma, @michelleellen]
+authors: [ferrymangmi, zxxma, michelleellen]
 ---
 
 # Gno.land Moderation DAO Module


### PR DESCRIPTION
The `@` symbol within the authors list is creating a strange YAML parsing error. Removing these symbols resolves the error.

![Screenshot 2023-10-31 at 8 57 37 AM](https://github.com/gnolang/blog/assets/17755587/9bc54b30-0f94-4f28-8ba5-08c7a85424ed)
