### PR TITLE
fix: duplicate titles

### DIFF
--- a/posts/2022-05-02_peace/README.md
+++ b/posts/2022-05-02_peace/README.md
@@ -6,8 +6,6 @@ tags: [peace, cosmos, "gno.land"]
 authors: [jaekwon]
 ---
 
-# Peace!
-
 I've never been put in such a difficult position, of having information that I
 cannot reveal. And if you know me, you know that I like to speak my mind.  But
 I cannot say the things that I would rather say, because you get a lot of flack

--- a/posts/2023-04-15_myg-march/README.md
+++ b/posts/2023-04-15_myg-march/README.md
@@ -12,8 +12,6 @@ We made progress across the board at Gno.land last month, from onboarding more d
 
 You can find the live streams of the new biweekly public developer calls on [Gno.land YouTube](https://www.youtube.com/@_gnoland/videos) as well as access the agendas on [GitHub](https://github.com/gnolang/meetings/blob/main/notes/2023_03_15_dev_call_notes.md). The main talking points this month were Gno IDE, Gno.land website language and UX, garbage collection, bug fixes, and how to bring IBC and ICS to the platform. We are working on all these issues concurrently but the order of release will be Gno.land mainnet, IBC, and then ICS (this is reflected in the DAG below).
 
-
-
 [![Gno.land mini DAG](https://gnolang.github.io/blog/2023-04-15_myg-march/src/thumbs/mini-dag.png)](https://gnolang.github.io/blog/2023-04-15_myg-march/src/mini-dag.png)
 
 ## Gno.land Website Language

--- a/posts/2023-05-26_myg-april/README.md
+++ b/posts/2023-05-26_myg-april/README.md
@@ -6,8 +6,6 @@ tags: [gnoland, gnovm, tm2]
 authors: [christina]
 ---
 
-## The More You Gno 2: Gno.land Developer Updates
-
 Over the past few weeks, our core devs and ecosystem contributors have been making massive strides on Gno.land. There’s a lot to cover in the second edition of *The More You Gno*, from updates on Tendermint2 and GnoVM to stack/frames management, Gno IDE, and plenty more. We’ll also see what some of the external teams contributing to the platform have been up to, including Gno.land’s first decentralized exchange, GnoSwap, and Adena compatibility with GRC20 tokens. Check it out.
 
 ## Tendermint2

--- a/posts/2023-07-11-myg-3/README.md
+++ b/posts/2023-07-11-myg-3/README.md
@@ -6,8 +6,6 @@ tags: [gnoland, gnovm, tm2]
 authors: [christina]
 ---
 
-## The More You Gno - Gno.land Monthly Updates 3
-
 We’ve been busy since the last edition of *The More You Gno,* with the Gno.land core team and ecosystem partners present at various global developer events. We’ve visited many gnomes (and gnomes-in-the-making) around the world from Berlin to Belgrade, spreading the word about Gno.land and growing our expanding community. Aside from all the networking, Gno.land is taking shape with a new iteration of our website, the Gno.land Funding and Grants Program, and a host of developer updates as always. Let’s dive in.
 
 ## Gno by Example

--- a/posts/2023-09-04-myg-4/README.md
+++ b/posts/2023-09-04-myg-4/README.md
@@ -6,8 +6,6 @@ tags: [gnoland, gnovm, tm2]
 authors: [christina]
 ---
 
-## The More You Gno 4: Gno.land Developer Updates
-
 We’ve had more on our plates than ever over the last few weeks, with a huge team presence in Paris at EthCC and Nebular Summit in July, an opening talk at Stanford Blockchain Club in August by Gno.land’s founder Jae Kwon, and some awesome contributions from Gno.land grantees and ecosystem partners, including the first demos of Gnoswap and Teritori’s social platform and DAO deployer. We continue to make solid progress on GnoVM, an alternative VM in Rust, Tendermint2, native bindings, and much more. Check out our latest developer updates below.
 
 ## Upgrade Strategy for AVL Between GitHub and test3.gno.land

--- a/posts/2023-10-10-myg-5/README.md
+++ b/posts/2023-10-10-myg-5/README.md
@@ -6,8 +6,6 @@ tags: [gnoland, gnovm, tm2]
 authors: [christina]
 ---
 
-# The More You Gno - Gno.land Monthly Updates 5
-
 It's been another productive month, packed with developer calls, live events, new contributors, a large team presence at the Go community's biggest event of the year, GopherCon 2023, and the launch of a PoC gaming dApp on Gno.land, GnoChess. We uncovered a bunch of bugs in the code and some issues with the GnoVM, and made further progress on the Go and Rust VMs, the banker module bug, Gnofee, and much more. Check out the updates below.
 
 ## Building a Web3 Chess Server on Gno.land - GnoChess

--- a/posts/2023-10-17_funding-program-q3/README.md
+++ b/posts/2023-10-17_funding-program-q3/README.md
@@ -6,8 +6,6 @@ tags: [gnoland, funding, grants]
 authors: [christina, michelle]
 ---
 
-# Gno.land Funding and Grants Program - Progress So Far
-
 # Quarterly Report: Q3 2023
 
 We launched the [Gno.land Funding and Grants](https://github.com/gnolang/ecosystem-fund-grants) program in July 2023 to encourage talented and passionate developers to interact with Gno.land, help build core infrastructure and tooling, and enhance the usability of the platform. After establishing a review process to streamline the program and identify core areas that need the most work, we ran with our first cohort of grantees in Q3, awarding four grants from a total of seven submissions (to two teams and two individuals). Full details of grant submissions, scope, and funding can be found on GitHub, but here’s a summary of the program’s progress so far and what’s coming up in Q4.

--- a/posts/2023-10-19_dao-moderation-module/README.md
+++ b/posts/2023-10-19_dao-moderation-module/README.md
@@ -6,7 +6,6 @@ tags: [gnoland, dao, moderation, teritori]
 authors: [ferrymangmi, zxxma, michelleellen]
 ---
 
-# Gno.land Moderation DAO Module
 *This blog post is written by the Teritori team, whose focus is to allow organizations to communicate and interact in a resilient and transparent way. Teritori is a partner and grantee of Gno.land.*
 
 When it comes to the complex subject of discussion forums and decentralized social networks, numerous technical and philosophical questions arise.

--- a/posts/2023-11-24_wyg-dongwon-shin/README.md
+++ b/posts/2023-11-24_wyg-dongwon-shin/README.md
@@ -6,7 +6,6 @@ tags: [whoyougno, onbloc, community, interview]
 authors: [christina]
 ---
 
-# Who You Gno – On the Record with Dongwon Shin
 *Who You Gno is intended to shine a light on the builders, contributors, and generally brilliant humans behind the tech. We’re excited to kick off this series with Dongwon Shin, the co-founder and CEO of one of Gno.land’s longest-contributing teams, Onbloc, a South Korean-based blockchain software company that builds key infrastructure and tooling for Gno.land*
 
 Since embarking on their Gno journey in late 2021, Dongwon and his team have been among the most active gnomes embodying the values of the Gno project: hardworking, passionate, honest, and humble, to name a few. You may already be familiar with Onbloc’s projects [Adena](https://adena.app/), [Gnoscan](https://gnoscan.io/), and [Gnoswap](https://github.com/gnoswap-labs) more about this can be found in [Onbloc's Hackerspace journey](https://github.com/gnolang/hackerspace/issues/29). In this interview, we’ll get the latest updates on these projects, hear about Dongwon the person, and learn more about what motivates him to be a gnome. Check it out.


### PR DESCRIPTION
## Description

This PR fixes duplicate titles. 

Duplicate titles appear because `gnoblog-cli` extracts the title of the post from the frontmatter and displays it at the top of the page - the fix is to remove the title from all post bodies, and just have it in the frontmatter. below is an example of how the issue looks on test3.

![Screenshot 2024-01-10 at 18 37 02](https://github.com/gnolang/blog/assets/33522493/d49a65bc-150a-460f-9964-476644eaded5)
