### PR TITLE
feat: add Discover gno.land @ GopherCon US 2024

### DIFF
--- a/posts/2024-07-03_discover-gno-gc24/README.md
+++ b/posts/2024-07-03_discover-gno-gc24/README.md
@@ -11,7 +11,7 @@ If you're attending GopherCon US this year, you may have heard about the
 [Challenge Series](https://www.gophercon.com/agenda/session/1281366) happening 
 during the conference. In addition to a the core set of challenges focused on 
 software engineering and cybersecurity provided by the Challenge Series organizers,
-the engineers at gno.land have brewed up a series of challenges that will introduce
+the engineers at gno.land have brewed up a set of challenges that will introduce
 you to blockchains and smart contracts, while still feeling right at home by 
 creating your solutions as Go and Gno programs!
 
@@ -56,7 +56,7 @@ each with a one-year subscription to 2600 Magazine and $100 in Google Cloud
 Platform credits. Plus, everyone who completes a challenge is eligible for 
 random prizes like vintage 2600 Magazine issues and security and programming 
 books, to be awarded to those present at the prize ceremony on Wednesday. The 
-full list of prizes can be found on the Challenge Series website..
+full list of prizes can be found on the [Challenge Series Prizes page](https://gophercon.challengeseries.org/prizes).
 
 ## Ready to Take on the Challenge?
 

--- a/posts/2024-07-03_discover-gno-gc24/README.md
+++ b/posts/2024-07-03_discover-gno-gc24/README.md
@@ -1,7 +1,7 @@
 ---
 publication_date: 2024-07-03T13:37:00Z
 slug: discover-gno-gc24
-tags: [ gnoland, test4, consensus, tm2, libtm ]
+tags: [ gnoland, gophercon, gno, challenge-series, go ]
 authors: [ leohhhn, deelawn, thehowl ]
 ---
 

--- a/posts/2024-07-03_discover-gno-gc24/README.md
+++ b/posts/2024-07-03_discover-gno-gc24/README.md
@@ -1,0 +1,90 @@
+---
+publication_date: 2024-07-03T13:37:00Z
+slug: discover-gno-gc24
+tags: [ gnoland, test4, consensus, tm2, libtm ]
+authors: [ leohhhn, deelawn, thehowl ]
+---
+
+# Discover gno.land at GopherCon US: Embrace Interpreted Go
+
+If you're attending GopherCon US this year, you may have heard about the 
+[Challenge Series](https://www.gophercon.com/agenda/session/1281366) happening 
+during the conference. In addition to a the core set of challenges focused on 
+software engineering and cybersecurity provided by the Challenge Series organizers,
+the engineers at gno.land have brewed up a series of challenges that will introduce
+you to blockchains and smart contracts, while still feeling right at home by 
+creating your solutions as Go and Gno programs!
+
+In the challenges, you'll learn how you can interact with a blockchain and discover
+how realms (smart contracts) can be utilized for stateful applications without 
+relying on a filesystem or a database. You'll also be able to leverage gno.land's
+features, such as using deployed contracts both as an API and as importable Gno 
+programs, while being aware of their limitations, like not being able to access 
+the system's time. And finally, you'll see what class of security problems come 
+up when you want to make smart contracts. Luckily, there are no SQL injections 
+to worry about here.
+
+## What is gno.land and Gno?
+
+gno.land is a distributed multiuser language-based operating system based on Go.
+It embeds a custom-built virtual machine that interprets and executes the Gno 
+language - a fully deterministic variant of Go. Set to become the leading 
+open-source smart contract platform, gno.land allows gophers to create 
+decentralized applications with a minimal learning curve.
+
+## How to Get Started
+
+You will be able to find the Gno challenges among the full catalogue on the 
+[Challenge Series website](https://gophercon.challengeseries.org/). There you
+will also find a guide that the engineers at gno.land have put together to help
+you get started, covering essential concepts and environment setup. This guide 
+will provide you with the tools and knowledge you need to effectively participate
+in solving Gno challenges.
+
+To participate, you'll have to form a team. You can join up with a team or look 
+for teammates by reaching out on the #gophercon-cs channel in the 
+[Gophers Slack](https://invite.slack.golangbridge.org/). We suggest 4-5 people 
+per team.
+
+Of course, it wouldn't be a competition without prizes! The winning team will
+score four tickets to GopherCon 2025, the second-place team will get gift cards
+for new hacking hardware, and the third-place team will receive copies of 
+"Go Programming: From Beginner to Professional" by Samantha Coyle, along with 
+cash prizes for all three top teams. We also have nine individual Achievement 
+awards, such as "First Blood!", "Night Owl!" and "Hooked on the Sidequest!", 
+each with a one-year subscription to 2600 Magazine and $100 in Google Cloud
+Platform credits. Plus, everyone who completes a challenge is eligible for 
+random prizes like vintage 2600 Magazine issues and security and programming 
+books, to be awarded to those present at the prize ceremony on Wednesday. The 
+full list of prizes can be found on the [website](https://gophercon.challengeseries.org/).
+
+## Ready to Take on the Challenge?
+
+- Join the Challenge Series: Test your wits & skills and gain practical 
+experience with Gno by visiting the [Challenge Series website](https://gophercon.challengeseries.org/).
+- Deepen your understanding of Gno and its core concepts by visiting the 
+[Official gno.land Documentation](https://docs.gno.land/)
+
+## Get to Gno Us @ GopherCon US
+
+If you'd like to learn more about Gno & gno.land, join us at GopherCon US for an
+in-depth talk and workshop on developing apps with Gno. Find the details below.
+
+### Workshop on 'Building a Decentralized App on gno.land'
+- Time & date: Monday, July 8th, 10:00 am - 12:00 pm
+- Who: Dylan Boltz, Software Engineer at gno.land
+- Where: Marina City, Marriott Marquis
+- [Link](https://www.gophercon.com/agenda?speakers=3317990)
+
+### Presentation: 'Building a Deterministic Interpreter in Go: Readability vs. Performance'
+- Time & date: Tuesday, July 9th, 11:45 am - 12:10 pm
+- Who: Jae Kwon, gno.land Founder and Co-founder of Cosmos
+- Where: Skyline Ballroom D, McCormick Place
+- [Link](https://www.gophercon.com/agenda?speakers=3304739)
+
+For more info, visit [gno.land](https://gno.land/gophercon24/) and stay connected 
+through our social media channels.
+
+We look forward to seeing you at GopherCon US and building the future with Gno.
+
+###### *Participation in the Challenge Series is only possible by physically attending GopherCon US 2024.

--- a/posts/2024-07-03_discover-gno-gc24/README.md
+++ b/posts/2024-07-03_discover-gno-gc24/README.md
@@ -36,10 +36,10 @@ decentralized applications with a minimal learning curve.
 
 You will be able to find the Gno challenges among the full catalogue on the 
 [Challenge Series website](https://gophercon.challengeseries.org/). There you
-will also find a guide that the engineers at gno.land have put together to help
-you get started, covering essential concepts and environment setup. This guide 
-will provide you with the tools and knowledge you need to effectively participate
-in solving Gno challenges.
+will also find [a guide](https://gophercon.challengeseries.org/gno) that the
+engineers at gno.land have put together to help you get started, covering 
+essential concepts and environment setup. This guide will provide you with the
+tools and knowledge you need to effectively participate in solving Gno challenges.
 
 To participate, you'll have to form a team. You can join up with a team or look 
 for teammates by reaching out on the #gophercon-cs channel in the 

--- a/posts/2024-07-03_discover-gno-gc24/README.md
+++ b/posts/2024-07-03_discover-gno-gc24/README.md
@@ -56,7 +56,7 @@ each with a one-year subscription to 2600 Magazine and $100 in Google Cloud
 Platform credits. Plus, everyone who completes a challenge is eligible for 
 random prizes like vintage 2600 Magazine issues and security and programming 
 books, to be awarded to those present at the prize ceremony on Wednesday. The 
-full list of prizes can be found on the [website](https://gophercon.challengeseries.org/).
+full list of prizes can be found on the Challenge Series website..
 
 ## Ready to Take on the Challenge?
 
@@ -70,7 +70,7 @@ experience with Gno by visiting the [Challenge Series website](https://gophercon
 If you'd like to learn more about Gno & gno.land, join us at GopherCon US for an
 in-depth talk and workshop on developing apps with Gno. Find the details below.
 
-### Workshop on 'Building a Decentralized App on gno.land'
+### Workshop: 'Building a Decentralized App on gno.land'
 - Time & date: Monday, July 8th, 10:00 am - 12:00 pm
 - Who: Dylan Boltz, Software Engineer at gno.land
 - Where: Marina City, Marriott Marquis


### PR DESCRIPTION
## Description

This PR introduces the blog post "Discover gno.land at GopherCon US: Embrace Interpreted Go". Written by @leohhhn, @thehowl, @deelawn, on July 3rd 2024.